### PR TITLE
Rebrand from nVotes to Sequent Tech

### DIFF
--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 name: ORT licensing

--- a/.ort-data/curations-dir/bsd_license.yml
+++ b/.ort-data/curations-dir/bsd_license.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 ---

--- a/.ort-data/curations-dir/distlib.yml
+++ b/.ort-data/curations-dir/distlib.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "PyPI::distlib"

--- a/.ort-data/curations-dir/drangandroptouch.yml
+++ b/.ort-data/curations-dir/drangandroptouch.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "dragandroptouch"

--- a/.ort-data/curations-dir/fractionjs.yml
+++ b/.ort-data/curations-dir/fractionjs.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "NPM::fraction.js"

--- a/.ort-data/curations-dir/java.yml
+++ b/.ort-data/curations-dir/java.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "Maven:javax.cache:cache-api"

--- a/.ort-data/curations-dir/jszip.yml
+++ b/.ort-data/curations-dir/jszip.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "NPM::jszip"

--- a/.ort-data/curations-dir/psycopg2-binary.yml
+++ b/.ort-data/curations-dir/psycopg2-binary.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "PyPI::psycopg2-binary"

--- a/.ort-data/curations-dir/pycryptodomex.yml
+++ b/.ort-data/curations-dir/pycryptodomex.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "PyPI::pycryptodomex"

--- a/.ort-data/curations-dir/reportlab.yml
+++ b/.ort-data/curations-dir/reportlab.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "PyPI::reportlab"

--- a/.ort-data/curations-dir/rng-js.yml
+++ b/.ort-data/curations-dir/rng-js.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "NPM::rng-js"

--- a/.ort-data/curations-dir/voting-booth.yml
+++ b/.ort-data/curations-dir/voting-booth.yml
@@ -1,10 +1,10 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
-- id: "Yarn::agora-gui-booth"
+- id: "Yarn::voting-booth"
   curations:
     comment: "This package needs to be downloaded from git"
     vcs:
       type: "git"
-      url: "https://github.com/agoravoting/agora-gui-common.git"
+      url: "https://github.com/sequentech/common-ui.git"
       revision: "4.0.1"

--- a/.ort-data/disclosure_document.ftl
+++ b/.ort-data/disclosure_document.ftl
@@ -1,7 +1,7 @@
 [#--
 SPDX-FileCopyrightText: 2020 HERE Europe B.V.
 SPDX-FileCopyrightText: 2020-2021 Bosch.IO GmbH
-SPDX-FileCopyrightText: 2021 Agora Voting SL
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc
 
 SPDX-License-Identifier: AGPL-3.0-only
 --]

--- a/.ort-data/license-classifications.yml
+++ b/.ort-data/license-classifications.yml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 # SPDX-FileCopyrightText: 2020-2021 Bosch.IO GmbH
 #
 # SPDX-License-Identifier: AGPL-3.0-only

--- a/.ort-data/rules.kts
+++ b/.ort-data/rules.kts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+ * SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
  * SPDX-FileCopyrightText: 2019 HERE Europe B.V.
  *
  * SPDX-License-Identifier: AGPL-3.0-only

--- a/.ort.yml
+++ b/.ort.yml
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
 ---
 resolutions:
   rule_violations:
-  - message: "The package PIP::agora-tools-requirements:.* has the declared ScanCode copyleft catalogized license AGPL-3.0-only."
+  - message: "The package PIP::misc-tools-requirements:.* has the declared ScanCode copyleft catalogized license AGPL-3.0-only."
     reason: "LICENSE_ACQUIRED_EXCEPTION"
     comment: "The project is open source so it's normal that it's set as such."
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,3 @@
 Víctor Ramirez de la Corte <virako.9 AT gmail DOT com>
-Eduardo Robles Elvira <edulix AT agoravoting DOT com>
+Eduardo Robles Elvira <edulix@sequentech.io>
 Daniel García Moreno <danigm AT wadobo DOT com>

--- a/CONFIG_UPDATES.md
+++ b/CONFIG_UPDATES.md
@@ -1,6 +1,6 @@
 # Config updates
 
-Sometimes, you have an election running, and unfortunately, you need to change the configuration. That shouldn't happen, but in practice it can happen. Usually, that means you need to start the election from the begining. That's a reasonable solution, but because in Agora Voting we want to be flexible, we want to provide alternatives in case you need them.
+Sometimes, you have an election running, and unfortunately, you need to change the configuration. That shouldn't happen, but in practice it can happen. Usually, that means you need to start the election from the begining. That's a reasonable solution, but because in Sequent Tech we want to be flexible, we want to provide alternatives in case you need them.
 
 These are the actions that we currently support:
 * Change question's maximum number of candidates that a user can choose and the number of winners candidates (1)
@@ -11,7 +11,7 @@ These are the actions that we currently support:
 
 More actions can be easily incorporated in the future as needed.
 
-Options marked with (1) mean that the change can be applied without creating a new election. This means that what needs to change is only the election configuration in for agora_elections, and the configuration used for calculating the results with agora-results.
+Options marked with (1) mean that the change can be applied without creating a new election. This means that what needs to change is only the election configuration in for ballot_box, and the configuration used for calculating the results with tally-pipes.
 
 Options marked with (2) mean that a new election is needed. In that case, the results of the two elections need to be consolidated to obtain the final results.
 
@@ -23,7 +23,7 @@ The config_updates.py script allows you to:
 
 This is useful if you have manually applied some updates. This script will check if the updates you have registered in the "updates CSV" are exactly the only updates applied, and if they have been applied.
 
-* generate or list the actions, commands, or configuration files to apply the updates in agora_election and agora-results
+* generate or list the actions, commands, or configuration files to apply the updates in sequent_election and tally-pipes
 
 Given an "updates CSV", it can generate list of actions that need to be taken for the yet unapplied changes. It can also generate the configuration files associated with the actions, and even list commands that need to be executed.
 
@@ -35,22 +35,22 @@ The format is very simple: A single table, with a list of columns describing som
 
 # Usage
 
-    mkvirtualenv agora-tools -p $(which python3)
-    workon agora-tools
+    mkvirtualenv misc-tools -p $(which python3)
+    workon misc-tools
     pip install -r requirements.txt
     config_updates.py -u updates.csv -c config.json --action check
-    config_updates.py -u updates.csv -c config.json --action show_agora_elections_commands
-    config_updates.py -u updates.csv -c config.json --action write_agora_results_files --dest-dir /tmp/agora-results-config
+    config_updates.py -u updates.csv -c config.json --action show_ballot_box_commands
+    config_updates.py -u updates.csv -c config.json --action write_tally_pipes_files --dest-dir /tmp/tally-pipes-config
 
 # Election results verification
 
-Once the election results have been calculated, a zip file with the results can be created which can be used by election authorities to reproduce the results. In order to create the zip, execute on an agora server, from user agoraelections, on agora-tools:
+Once the election results have been calculated, a zip file with the results can be created which can be used by election authorities to reproduce the results. In order to create the zip, execute on an sequent server, from user ballotbox, on misc-tools:
 
     python3 config_updates.py -c config/config_example.json -e /path/to/folder -i /path/to/election-ids.txt -p <PASSWORD> -a create_verifiable_results
 
 This will create a zip file called verify.zip on path /path/to/folder with password <PASSWORD>, for elections with the election ids listed on file /path/to/election-ids.txt
 
-Then, copy verify.zip to an election authority, and unzip it on a folder (example: /path/to/folder) and, from user eorchestra, on /home/eorchestra/agora-tools, execute:
+Then, copy verify.zip to an election authority, and unzip it on a folder (example: /path/to/folder) and, from user eorchestra, on /home/eorchestra/misc-tools, execute:
 
      $ python3 config_updates.py -e /path/to/folder -a verify_results
 

--- a/README.md
+++ b/README.md
@@ -10,21 +10,21 @@ election:
 
     python3 import_election_csv.py --config config/config_example.json -i config/test.csv -o config/test-dir -f csv-google-forms
 
-# agora-admin.py script
+# sequent-admin.py script
 
 ## Introduction
 
-Script to manage elections using both agora-elections and authapi together. It
+Script to manage elections using both ballot-box and iam together. It
 allows to:
   - create an election with a census
-  - start or stop the election in authapi
+  - start or stop the election in iam
   - send auth messages to the census
 
 This script does not (currently) pretend to allow to do all the actions related
-to agora-elections or authapi, only those related to authapi. In cases those
-actions are also related to agora-elections and if it makes sense, like creating
+to ballot-box or iam, only those related to iam. In cases those
+actions are also related to ballot-box and if it makes sense, like creating
 an election in both, then it allows that. But the admin/admin.py script from
-agora-elections still manages other agora-elections specific tasks like doing
+ballot-box still manages other ballot-box specific tasks like doing
 a tally, for example.
 
 ## Plugin system
@@ -37,16 +37,16 @@ arguments and functions that execute this arguments. There is a example in plugi
 For any of the actions, you need to provide the --config file (see
 config/config_example.json for an example):
 
-    ./agora-admin --config config/config_example.json
+    ./sequent-admin --config config/config_example.json
 
-This configuration file format is shared/global with other agora-tools commands
+This configuration file format is shared/global with other misc-tools commands
 like import_election_csv.py or config_updates.py
 
 Then you execute any of the actions:
 
 ### Create elections
 
-To create an election with a census both in agora-elections and authapi, you
+To create an election with a census both in ballot-box and iam, you
 need to provide a directory with numbered files so that for each election you
 have 3 files: **id**.json, **id**.census.json and **id**.config.json. These
 files can be generated with the  import_election_csv.py script or by other
@@ -55,31 +55,31 @@ means. For example:
     $ ls data/example
     781.json 781.json 781.config.json
 
-    $ ./agora-admin.py --config config/config_example.json --create data/example
+    $ ./sequent-admin.py --config config/config_example.json --create data/example
 
 Note that the ids of the files are only to attach the files together, because
-the id is actually set on creation by authapi and printed on screen.
+the id is actually set on creation by iam and printed on screen.
 
 # Start or stop an election
 
-You can start or stop an election in authapi following this example:
+You can start or stop an election in iam following this example:
 
-    $ ./agora-admin.py --config config/config_example.json --start id
-    $ ./agora-admin.py --config config/config_example.json --stop id
+    $ ./sequent-admin.py --config config/config_example.json --start id
+    $ ./sequent-admin.py --config config/config_example.json --stop id
 
 # Send authentication codes to census
 
 To send the authentication codes to the census using the message format
 specified in the config file, use:
 
-    $ ./agora-admin.py --config config/config_example.json --send-auth-codes id
+    $ ./sequent-admin.py --config config/config_example.json --send-auth-codes id
 
 ### Agora admin complete election:
 
-    $ ./agora-admin.py -C vota1.config.json -c data/vota1/
-    $ ./agora-admin.py -C vota1.config.json --start ID
-    $ ./agora-admin.py -C vota1.config.json --send-auth-codes ID
-    $ ./agora-admin.py -C vota1.config.json --stop ID
-    $ ./agora-admin.py -C vota1.config.json --tally ID
-    $ ./agora-admin.py -C vota1.config.json --calculate ID
-    $ ./agora-admin.py -C vota1.config.json --publish ID
+    $ ./sequent-admin.py -C vota1.config.json -c data/vota1/
+    $ ./sequent-admin.py -C vota1.config.json --start ID
+    $ ./sequent-admin.py -C vota1.config.json --send-auth-codes ID
+    $ ./sequent-admin.py -C vota1.config.json --stop ID
+    $ ./sequent-admin.py -C vota1.config.json --tally ID
+    $ ./sequent-admin.py -C vota1.config.json --calculate ID
+    $ ./sequent-admin.py -C vota1.config.json --publish ID

--- a/admin.py
+++ b/admin.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python
 
-# This file is part of agora-tools.
-# Copyright (C) 2014-2016  Agora Voting SL <agora@agoravoting.com>
+# This file is part of misc-tools.
+# Copyright (C) 2014-2016  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-tools is free software: you can redistribute it and/or modify
+# misc-tools is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-tools  is distributed in the hope that it will be useful,
+# misc-tools  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-tools.  If not, see <http://www.gnu.org/licenses/>.
+# along with misc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
 import requests
 import json
@@ -700,7 +700,7 @@ def __load_node_votes(cfg):
     print("> inserted %d votes" % len(vs))
 
 def main(argv):
-    parser = argparse.ArgumentParser(description='agora-api admin script', formatter_class=RawTextHelpFormatter)
+    parser = argparse.ArgumentParser(description='sequent-api admin script', formatter_class=RawTextHelpFormatter)
     parser.add_argument('command', nargs='+', help='''create <election_dir>: creates an election
 tally <election_dir>: launches tally
 list_votes <election_dir>: list votes

--- a/config/config_example.json
+++ b/config/config_example.json
@@ -1,21 +1,21 @@
 {
-  "director": "agora-auth5",
+  "director": "sequent-auth5",
   "authorities": ["openkratio-auth2"],
-  "agora_results_config": [
+  "tally_pipes_config": [
     [
-      "agora_results.pipes.results.do_tallies",
+      "tally_pipes.pipes.results.do_tallies",
       {"ignore_invalid_votes": true}
     ]
   ],
-  "agora_results_config_sorting": [
+  "tally_pipes_config_sorting": [
     [
-      "agora_results.pipes.sort.sort_non_iterative",
+      "tally_pipes.pipes.sort.sort_non_iterative",
       {"question_indexes": [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]}
     ]
   ],
-  "agora_elections_base_url": "http://localhost:9000/api",
-  "agora_results_bin_path": "/home/agoraelections/agora-tools/agora_results.sh",
-  "agora_elections_private_datastore_path": "/home/agoraelections/datastore/private/",
+  "ballot_box_base_url": "http://localhost:9000/api",
+  "tally_pipes_bin_path": "/home/ballotbox/misc-tools/tally_pipes.sh",
+  "ballot_box_private_datastore_path": "/home/ballotbox/datastore/private/",
   "global_prechanges": [
     [
       "map_question_maximums_and_winners",
@@ -24,7 +24,7 @@
       }
     ]
   ],
-  "authapi": {
+  "iam": {
     "credentials": {
       "username": "admin",
       "password": "admin"

--- a/eopeers.py
+++ b/eopeers.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python
 
-# This file is part of agora-tools.
-# Copyright (C) 2014-2016  Agora Voting SL <agora@agoravoting.com>
+# This file is part of misc-tools.
+# Copyright (C) 2014-2016  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-tools is free software: you can redistribute it and/or modify
+# misc-tools is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-tools  is distributed in the hope that it will be useful,
+# misc-tools  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-tools.  If not, see <http://www.gnu.org/licenses/>.
+# along with misc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
 import os

--- a/eotasks.py
+++ b/eotasks.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# This file is part of agora-tools.
-# Copyright (C) 2014-2020  Agora Voting SL <contact@nvotes.com>
+# This file is part of misc-tools.
+# Copyright (C) 2014-2020  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-tools is free software: you can redistribute it and/or modify
+# misc-tools is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-tools  is distributed in the hope that it will be useful,
+# misc-tools  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-tools.  If not, see <http://www.gnu.org/licenses/>.
+# along with misc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
 import os

--- a/eotest.py
+++ b/eotest.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
 
-# This file is part of agora-tools.
-# Copyright (C) 2014-2020  Agora Voting SL <contact@nvotes.com>
+# This file is part of misc-tools.
+# Copyright (C) 2014-2020  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-tools is free software: you can redistribute it and/or modify
+# misc-tools is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-tools  is distributed in the hope that it will be useful,
+# misc-tools  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-tools.  If not, see <http://www.gnu.org/licenses/>.
+# along with misc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
 import requests
 import ssl

--- a/import_election_csv.py
+++ b/import_election_csv.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# This file is part of agora-tools.
-# Copyright (C) 2014-2016  Agora Voting SL <agora@agoravoting.com>
+# This file is part of misc-tools.
+# Copyright (C) 2014-2016  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-tools is free software: you can redistribute it and/or modify
+# misc-tools is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-tools  is distributed in the hope that it will be useful,
+# misc-tools  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-tools.  If not, see <http://www.gnu.org/licenses/>.
+# along with misc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
 import csv
@@ -61,7 +61,7 @@ BASE_ELECTION = {
         {
           "network": "Twitter",
           "button_text": "",
-          "social_message": "I have just voted in election __URL__, you can too! #nvotes"
+          "social_message": "I have just voted in election __URL__, you can too! #sequent"
         },
         {
           "network": "Facebook",
@@ -155,7 +155,7 @@ def blocks_to_election(blocks, config, add_to_id=0):
 
     def get_url(key, value):
         if key in ['Gender', 'Tag', 'Support']:
-            return "https://agoravoting.com/api/%s/%s" % (key.lower(), value)
+            return "https://sequentech.io/api/%s/%s" % (key.lower(), value)
         elif value.startswith('http://') or value.startswith('https://'):
             return value.strip()
 
@@ -277,7 +277,7 @@ def form_to_elections(path, separator, config, add_to_id):
     more_keys = {
         "¿Más preguntas?": lambda v: "No" not in v
     }
-    auth_method = config['authapi']['event_config']['auth_method']
+    auth_method = config['iam']['event_config']['auth_method']
     question_options_key = "Opciones"
     question_funcs = {
         "Título": lambda d: ["title", d],
@@ -345,7 +345,7 @@ if __name__ == '__main__':
     parser.add_argument('-c', '--config-path', help='default config for the election')
     parser.add_argument('-i', '--input-path', help='input file or directory')
     parser.add_argument('-o', '--output-path', help='output file or directory')
-    parser.add_argument('-A', '--admin-format', help='use create format for agora-admin instead of agora-elections', action="store_true")
+    parser.add_argument('-A', '--admin-format', help='use create format for sequent-admin instead of ballot-box', action="store_true")
     parser.add_argument('-a', '--add-to-id', type=int, help='add an int number to the id', default=0)
     parser.add_argument(
         '-f', '--format',
@@ -401,12 +401,12 @@ if __name__ == '__main__':
                     else:
                         output_path = os.path.join(args.output_path, str(i) + ".json")
                         auth_config_path = os.path.join(args.output_path, str(i) + ".config.json")
-                        auth_config = config['authapi']['event_config']
+                        auth_config = config['iam']['event_config']
                         with open(auth_config_path, mode='w', encoding="utf-8", errors='strict') as f:
                             f.write(serialize(auth_config))
 
                         auth_census_path = os.path.join(args.output_path, str(i) + ".census.json")
-                        census_config = config['authapi'].get('census_data', [])
+                        census_config = config['iam'].get('census_data', [])
                         with open(auth_census_path, mode='w', encoding="utf-8", errors='strict') as f:
                             f.write(serialize(census_config))
 
@@ -414,7 +414,7 @@ if __name__ == '__main__':
                     with open(output_path, mode='w', encoding="utf-8", errors='strict') as f:
                         f.write(serialize(election))
 
-                    if config.get('agora_results_config', None) is not None:
+                    if config.get('tally_pipes_config', None) is not None:
                         if not args.admin_format:
                             results_conf_path = os.path.join(args.output_path, str(election['id']) + ".config.results.json")
                         else:
@@ -427,7 +427,7 @@ if __name__ == '__main__':
                             f.write(serialize(
                                 dict(
                                     version="1.0",
-                                    pipes=config['agora_results_config']
+                                    pipes=config['tally_pipes_config']
                                 )
                             ))
                     i += 1
@@ -463,7 +463,7 @@ if __name__ == '__main__':
 
                 fpath = os.path.join(args.output_path, "%d.config.json" % election["id"])
                 with open(fpath, mode='w', encoding="utf-8", errors='strict') as f:
-                    f.write(serialize(config['authapi']['event_config']))
+                    f.write(serialize(config['iam']['event_config']))
     except:
         print("malformed CSV")
         import traceback

--- a/khmac_gen.py
+++ b/khmac_gen.py
@@ -1,19 +1,19 @@
 ##!/usr/bin/env python3
 
-# This file is part of agora-tools.
-# Copyright (C) 2014-2016  Agora Voting SL <agora@agoravoting.com>
+# This file is part of misc-tools.
+# Copyright (C) 2014-2016  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-tools is free software: you can redistribute it and/or modify
+# misc-tools is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-tools  is distributed in the hope that it will be useful,
+# misc-tools  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-tools.  If not, see <http://www.gnu.org/licenses/>.
+# along with misc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
 import hashlib

--- a/plugin_plugin.py
+++ b/plugin_plugin.py
@@ -1,17 +1,17 @@
-# This file is part of agora-tools.
-# Copyright (C) 2014-2016  Agora Voting SL <agora@agoravoting.com>
+# This file is part of misc-tools.
+# Copyright (C) 2014-2016  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-tools is free software: you can redistribute it and/or modify
+# misc-tools is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-tools  is distributed in the hope that it will be useful,
+# misc-tools  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-tools.  If not, see <http://www.gnu.org/licenses/>.
+# along with misc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
 add_arguments = [
         ['--plugins', {'action': 'store_true', 'help': 'Show too active plugins.'}]

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,32 @@
 #!/usr/bin/env python3
 
-# This file is part of agora-results.
-# Copyright (C) 2014-2021  Agora Voting SL <contact@nvotes.com>
+# This file is part of tally-pipes.
+# Copyright (C) 2014-2021  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-results is free software: you can redistribute it and/or modify
+# tally-pipes is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-results  is distributed in the hope that it will be useful,
+# tally-pipes  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-results.  If not, see <http://www.gnu.org/licenses/>.
+# along with tally-pipes.  If not, see <http://www.gnu.org/licenses/>.
 
 from setuptools import setup
 
 setup(
-    name='agora-tools',
+    name='misc-tools',
     version='master',
-    author='Agora Voting SL',
-    author_email='contact@nvotes.com',
+    author='Sequent Tech Inc',
+    author_email='legal@sequentech.io',
     packages=[],
     scripts=[],
-    url='http://github.com/agoravoting/agora-tools/',
+    url='http://github.com/sequentech/misc-tools/',
     license='AGPL-3.0',
-    description='agora tools',
+    description='sequent tools',
     long_description=open('README.md').read(),
     install_requires=[
         'SQLAlchemy==1.3.0',

--- a/utils/apply_election_changes.py
+++ b/utils/apply_election_changes.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of agora-tools.
-# Copyright (C) 2014-2016  Agora Voting SL <agora@agoravoting.com>
+# This file is part of misc-tools.
+# Copyright (C) 2014-2016  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-tools is free software: you can redistribute it and/or modify
+# misc-tools is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-tools  is distributed in the hope that it will be useful,
+# misc-tools  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-tools.  If not, see <http://www.gnu.org/licenses/>.
+# along with misc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
 def change_question_max(change, election_config, **kwargs):
     '''

--- a/utils/csvblocks.py
+++ b/utils/csvblocks.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of agora-tools.
-# Copyright (C) 2014-2016  Agora Voting SL <agora@agoravoting.com>
+# This file is part of misc-tools.
+# Copyright (C) 2014-2016  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-tools is free software: you can redistribute it and/or modify
+# misc-tools is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-tools  is distributed in the hope that it will be useful,
+# misc-tools  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-tools.  If not, see <http://www.gnu.org/licenses/>.
+# along with misc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 try:

--- a/utils/deterministic_tar.py
+++ b/utils/deterministic_tar.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of agora-tools.
-# Copyright (C) 2014-2016  Agora Voting SL <agora@agoravoting.com>
+# This file is part of misc-tools.
+# Copyright (C) 2014-2016  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-tools is free software: you can redistribute it and/or modify
+# misc-tools is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-tools  is distributed in the hope that it will be useful,
+# misc-tools  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-tools.  If not, see <http://www.gnu.org/licenses/>.
+# along with misc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import time

--- a/utils/hashed_changes.py
+++ b/utils/hashed_changes.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of agora-tools.
-# Copyright (C) 2014-2016  Agora Voting SL <agora@agoravoting.com>
+# This file is part of misc-tools.
+# Copyright (C) 2014-2016  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-tools is free software: you can redistribute it and/or modify
+# misc-tools is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-tools  is distributed in the hope that it will be useful,
+# misc-tools  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-tools.  If not, see <http://www.gnu.org/licenses/>.
+# along with misc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
 import hashlib
 import collections

--- a/utils/json_serialize.py
+++ b/utils/json_serialize.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of agora-tools.
-# Copyright (C) 2014-2016  Agora Voting SL <agora@agoravoting.com>
+# This file is part of misc-tools.
+# Copyright (C) 2014-2016  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-tools is free software: you can redistribute it and/or modify
+# misc-tools is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-tools  is distributed in the hope that it will be useful,
+# misc-tools  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-tools.  If not, see <http://www.gnu.org/licenses/>.
+# along with misc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
 from json import *

--- a/utils/prechanges_check.py
+++ b/utils/prechanges_check.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of agora-tools.
-# Copyright (C) 2014-2016  Agora Voting SL <agora@agoravoting.com>
+# This file is part of misc-tools.
+# Copyright (C) 2014-2016  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-tools is free software: you can redistribute it and/or modify
+# misc-tools is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-tools  is distributed in the hope that it will be useful,
+# misc-tools  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-tools.  If not, see <http://www.gnu.org/licenses/>.
+# along with misc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
 def map_question_maximums_and_winners(election_config, election_id, mapping):
     '''

--- a/utils/prechanges_results.py
+++ b/utils/prechanges_results.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of agora-tools.
-# Copyright (C) 2014-2016  Agora Voting SL <agora@agoravoting.com>
+# This file is part of misc-tools.
+# Copyright (C) 2014-2016  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-tools is free software: you can redistribute it and/or modify
+# misc-tools is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-tools  is distributed in the hope that it will be useful,
+# misc-tools  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-tools.  If not, see <http://www.gnu.org/licenses/>.
+# along with misc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
 def map_question_maximums_and_winners(election_config, election_id, ancestors,
     mapping, **kwargs):

--- a/utils/tree.py
+++ b/utils/tree.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of agora-tools.
-# Copyright (C) 2014-2016  Agora Voting SL <agora@agoravoting.com>
+# This file is part of misc-tools.
+# Copyright (C) 2014-2016  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-tools is free software: you can redistribute it and/or modify
+# misc-tools is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-tools  is distributed in the hope that it will be useful,
+# misc-tools  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-tools.  If not, see <http://www.gnu.org/licenses/>.
+# along with misc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
 import collections
 

--- a/verify_results.sh
+++ b/verify_results.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
 
-# This file is part of agora-tools.
-# Copyright (C) 2014-2016  Agora Voting SL <agora@agoravoting.com>
+# This file is part of misc-tools.
+# Copyright (C) 2014-2016  Sequent Tech Inc <legal@sequentech.io>
 
-# agora-tools is free software: you can redistribute it and/or modify
+# misc-tools is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License.
 
-# agora-tools  is distributed in the hope that it will be useful,
+# misc-tools  is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with agora-tools.  If not, see <http://www.gnu.org/licenses/>.
+# along with misc-tools.  If not, see <http://www.gnu.org/licenses/>.
 
 export TMP_DIR=/tmp/orig
-export AGORA_RESULTS_PATH=/home/agoraelections/agora-results
+export SEQUENT_RESULTS_PATH=/home/ballotbox/tally-pipes
 export BASE_TARS_URL=/srv/election-orchestra/server1/public/
-export TARS_PATH=/home/agoraelections/tars
+export TARS_PATH=/home/ballotbox/tars
 export TARFILE=$(realpath $1)
-export VIRTUALENV=/home/agoraelections/.virtualenvs/agora-tools
+export VIRTUALENV=/home/ballotbox/.virtualenvs/misc-tools
 
 if [ "$(whoami)" != "root" ]
 then
@@ -52,9 +52,9 @@ do
     fi
   fi
 
-  echo "executing '$AGORA_RESULTS_PATH/agora-results -c $TMP_DIR/${i}.config.results.json -t ${TARS_PATH}/${i}.tar.gz -s -o pretty'.."
+  echo "executing '$SEQUENT_RESULTS_PATH/tally-pipes -c $TMP_DIR/${i}.config.results.json -t ${TARS_PATH}/${i}.tar.gz -s -o pretty'.."
 
-  $AGORA_RESULTS_PATH/agora-results -c ${i}.config.results.json -t "${TARS_PATH}/${i}.tar.gz" -s -o pretty > "${i}.results.mine.pretty"
+  $SEQUENT_RESULTS_PATH/tally-pipes -c ${i}.config.results.json -t "${TARS_PATH}/${i}.tar.gz" -s -o pretty > "${i}.results.mine.pretty"
   [ $? != 0 ] && echo "error executing previous command" && exit 1
 
   my_md5=$(md5sum "${i}.results.mine.pretty" | cut -b-32)


### PR DESCRIPTION
Rebrands the whole repository from nVotes to Sequent Tech, changing all references in code, documentation, comments and file names. This rebranding includes the renaming of all the repositories too.