### PR TITLE
Add keys ceremonies 

### DIFF
--- a/eopeers.py
+++ b/eopeers.py
@@ -170,7 +170,7 @@ def install(PEER_LIST, path, keystore=None):
         with open(temppem, "w") as f:
             f.write(el_json["ssl_certificate"])
             #keytool --delete mykey -keystore keystore.jks
-        subprocess.call("keytool -noprompt -import -file %s -keystore %s -storepass '%s'" % (temppem, keystore, CONFIG['KEYSTORE_PASS']), shell=True)
+        subprocess.call("keytool -noprompt -import -file %s -keystore %s -storepass '%s' -alias %s" % (temppem, keystore, CONFIG['KEYSTORE_PASS'], bname), shell=True)
         os.unlink(temppem)
 
 def uninstall(PEER_LIST, hostname, keystore=None):
@@ -220,7 +220,7 @@ def uninstall(PEER_LIST, hostname, keystore=None):
     if keystore:
         keystore = keystore[0]
         # removing the key from the keystore
-        subprocess.call("keytool -noprompt -delete -alias mykey -keystore %s -storepass '%s'" % (keystore, CONFIG['KEYSTORE_PASS']), shell=True)
+        subprocess.call("keytool -noprompt -delete -alias %s -keystore %s -storepass '%s'" % (hostname, keystore, CONFIG['KEYSTORE_PASS']), shell=True)
 
 def showmine(pargs):
     '''


### PR DESCRIPTION
# Changes

Set the alias for keys in the keystore to be the name of the trustee, to support the keys ceremonies. Otherwise when you try to add the keys for the second trustee, the keys from the first one are rewritten.