### PR TITLE
`master` branch should be using `master` version number and not `8.0.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup
 
 setup(
     name='misc-tools',
-    version='8.0.0',
+    version='master',
     author='Sequent Tech Inc',
     author_email='legal@sequentech.io',
     packages=[],


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/136

Revert "Release for version 8.0.0"

This reverts commit 1337107fa1fecd7d9ceb09fe5f505aa9ee87e094.